### PR TITLE
Update SmartyView.php - Can't use smarty in email

### DIFF
--- a/View/SmartyView.php
+++ b/View/SmartyView.php
@@ -42,7 +42,7 @@ class SmartyView extends View
      *
      * @param  $controller instance of calling controller
      */
-	function __construct (&$controller)
+	function __construct ($controller)
 	{
 		parent::__construct($controller);
 


### PR DESCRIPTION
Can't use smarty with email
Error: Cannot pass parameter 1 by reference 
File: /var/www/clients/client4/web246/web/lib/Cake/Network/Email/CakeEmail.php  
Line: 1631

Cake don't modify that var so no need for reference?
