### PR TITLE
PHP 5.4 Call-time pass-by-reference

### DIFF
--- a/View/SmartyView.php
+++ b/View/SmartyView.php
@@ -160,7 +160,7 @@ class SmartyView extends View
             list($plugin, $helper) = $this->pluginSplit($helper);
             $helperClass = $helper. 'Helper';
             if (property_exists($this, $helper) && method_exists($this->{$helper}, '_registerSmartyFunctions')) {
-                $this->{$helper}->_registerSmartyFunctions(&$this->Smarty);
+                $this->{$helper}->_registerSmartyFunctions($this->Smarty);
 			}
 		}
 	}


### PR DESCRIPTION
PHP Fatal error:  Call-time pass-by-reference has been removed in plugins\SmartyView\View\SmartyView.php on line 163
