### PR TITLE
Update SmartyHtmlHelper.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Works with Smarty version 2.6 and 3.1 both.
 
 In plugin directory of your app:
 
-    git git://github.com/news2u/cakephp-smartyview.git SmartyView
+    git submodule add git://github.com/news2u/cakephp-smartyview.git SmartyView
 
 ## How to use
 

--- a/View/Helper/SmartyHtmlHelper.php
+++ b/View/Helper/SmartyHtmlHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-
+App::uses('SmartyBaseHelper', 'SmartyView.View/Helper');
 
 /**
  * SmartyHtml Helper class for wrapping HtmlHelper methods


### PR DESCRIPTION
For whatever reason, this import was left out - causing fatal errors. I simply added the missing SmartBaseHelper import.
I also modified the readme, as it was missing the command terms in the git line.
